### PR TITLE
feat: template formats override, don't parse unnecessary files

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ module.exports = {
             watch : true,
 
             // directory to watch; default directory of @lxg/l10n
-            watchDir : "l10n"
+            watchDir : "l10n",
+
+            // template formats that should be parsed by the plugin
+            templateFormats: undefined
         }, options)
 
         // We have a bit of async stuff here. First, because we need to import an ES module
@@ -42,11 +45,15 @@ module.exports = {
         })
 
         eleventyConfig.addTransform("l10n-translate", function(content, path) {
-            const lang = options.langCallback(this, path, content) || "en"
+            const templateFormats = options.templateFormats || eleventyConfig.templateFormats || this.templateData.config.templateFormats
+            const isHtmlTemplate = templateFormats.some((ext) => path.endsWith(`.${ext}`))
 
-            return this.templateData.config.templateFormats.some(ext => path.endsWith(`.${ext}`))
-                ? l10nHtml(content, translations, lang)
-                : content
+            if (!isHtmlTemplate) {
+                return content
+            }
+
+            const lang = options.langCallback(this, path, content) || "en"
+            return l10nHtml(content, translations, lang)
         })
 
         options.watch &&


### PR DESCRIPTION
This PR introduces following:
- `templateFormats` override option
- exit early if file should not be parsed
- get `templateFormats` from `options` -> `eleventyConfig` -> `context`

I made this change mostly due to a problem with eleventy 1.0.0 in which `this` contains only the file path, so `templateFormats` could not be found.
Additionally `templateFormats` on eleventyConfig is set only when user sets it via `setTemplateFormats` which is not always needed. Therefore options override is introduced.